### PR TITLE
Loosen faraday_middleware dependency

### DIFF
--- a/yotpo.gemspec
+++ b/yotpo.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'faraday'
   gem.add_dependency 'typhoeus'
-  gem.add_dependency 'faraday_middleware', '>= 0.8', '< 0.10'
+  gem.add_dependency 'faraday_middleware'
   gem.add_dependency 'hashie'
   gem.add_dependency 'oj'
   gem.add_dependency 'activesupport'


### PR DESCRIPTION
In order to allow compatibility with other gems, we should loosen the
dependency on `faraday_middleware`. The specs still pass, so I figure the changes needed to support the newer version were made some time ago.