### PR TITLE
Update bottom_lines endpoint path

### DIFF
--- a/lib/yotpo/api/product.rb
+++ b/lib/yotpo/api/product.rb
@@ -8,7 +8,7 @@ module Yotpo
       }
       request.delete_if{|key,val| val.nil?}
       app_key = params[:app_key]
-      get("/apps/#{app_key}/bottom_lines", request, headers)
+      get("/v1/apps/#{app_key}/bottom_lines", request, headers)
     end
 
     def get_products_information(params, headers = {})

--- a/spec/api/product_spec.rb
+++ b/spec/api/product_spec.rb
@@ -21,11 +21,16 @@ describe Yotpo::Product do
 
   describe '#get_all_bottom_lines' do
     before(:all) do
+      VCR.configure do |c|
+        c.filter_sensitive_data('YOTPO_APP_KEY') { @app_key }
+        c.filter_sensitive_data('YOTPO_TOKEN') { @utoken }
+      end
+
       get_app_bottom_lines_params = {
           utoken: @utoken,
           app_key: @app_key
       }
-      VCR.use_cassette('check_minisite_subdomain') do
+      VCR.use_cassette('get_all_bottom_lines') do
         @response = Yotpo.get_all_bottom_lines(get_app_bottom_lines_params)
       end
     end

--- a/spec/cassettes/get_all_bottom_lines.yml
+++ b/spec/cassettes/get_all_bottom_lines.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yotpo.com/v1/apps/YOTPO_APP_KEY/bottom_lines?utoken=YOTPO_TOKEN
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Yotpo-Api-Connector:
+      - Ruby1.0.6
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Sat, 16 Jan 2021 02:09:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Robots-Tag:
+      - noindex
+      Etag:
+      - W/"ff0fbde54be6b9e5c6986d1fa23808c4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2a70d3a1-00e0-4221-8662-1d3f5cbb0819
+      X-Runtime:
+      - '0.064447'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      P3p:
+      - policyref="/w3c/p3p.xml", CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi
+        CONi HIS OUR IND CNT", CP="CAO PSA OUR"
+      X-Ratelimit-Remaining-Minute:
+      - '4999'
+      X-Ratelimit-Limit-Minute:
+      - '5000'
+      Ratelimit-Remaining:
+      - '4999'
+      Ratelimit-Limit:
+      - '5000'
+      Ratelimit-Reset:
+      - '53'
+      X-Kong-Upstream-Latency:
+      - '69'
+      X-Kong-Proxy-Latency:
+      - '8'
+      Via:
+      - kong/2.1.4
+    body:
+      encoding: UTF-8
+      string: '{"status":{"code":200,"message":"ok"},"response":{"bottomlines":[{"domain_key":"J1A1063","product_score":4.55769,"total_reviews":156},{"domain_key":"J1D1147","product_score":4.12317,"total_reviews":2395},{"domain_key":"J1D1023","product_score":4.2074,"total_reviews":3081},{"domain_key":"AUTOSHIP","product_score":4.68317,"total_reviews":202},{"domain_key":"J1T1419","product_score":4.19407,"total_reviews":6714},{"domain_key":"J1T1028","product_score":4.13415,"total_reviews":2199},{"domain_key":"J1T1193","product_score":5.0,"total_reviews":1},{"domain_key":"J1T1025","product_score":3.43082,"total_reviews":2219},{"domain_key":"J1T1024","product_score":4.00757,"total_reviews":2114},{"domain_key":"J1T1443","product_score":3.7926,"total_reviews":1432}],"page":1,"per_page":10}}'
+  recorded_at: Sat, 16 Jan 2021 02:09:07 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Adds the v1 path prefix to the request path in Yotpo::Product#get_all_bottom_lines, which is required
for this endpoint to work according to the latest API documentation: https://apidocs.yotpo.com/reference#v1-retrieve-bottom-line-total-reviews-and-average-score-for-all-products.